### PR TITLE
Fix dumping failure in some cases

### DIFF
--- a/weak_classdump.cy
+++ b/weak_classdump.cy
@@ -82,7 +82,7 @@ function getProtocolLines(protocol){
 					protSelector=protMeths[gg][0].toString();
 					protTypes=protMeths[gg][1];
 					protTypes=[protTypes stringByRemovingCharactersFromSet: [NSCharacterSet decimalDigitCharacterSet ]];
-					protTypes=[[NSString stringWithString:protTypes] stringByReplacingOccurrencesOfString:@"@:" withString:""];
+					protTypes=[[NSString stringWithString:protTypes] stringByReplacingCharactersInRange:[1,2] withString:""];
 					returnType=[protTypes substringToIndex: 1]; 
 					returnType=commonTypes(returnType);
 					finString="";


### PR DESCRIPTION
Consider a message like `tableView:canPerfomAction:forRowAtIndexPath:withSender:` (`c@:@:@@`)
